### PR TITLE
Make Errors easily raisable

### DIFF
--- a/src/serialite/__init__.py
+++ b/src/serialite/__init__.py
@@ -2,7 +2,7 @@ from ._base import Serializable, Serializer
 from ._dataclass import field
 from ._decorators import abstract_serializable, serializable
 from ._dispatcher import serializer
-from ._errors import Errors, ValidationError
+from ._errors import ErrorElement, Errors, ValidationError, ValidationExceptionGroup, raise_errors
 from ._field_errors import (
     ConflictingFieldsError,
     RequiredFieldError,


### PR DESCRIPTION
- Add `ValidationExceptionGroup` as the exception that is raised by `Errors`
- Add `Errors.raise_on_errors` method to raise if there are errors and do nothing if not
- Add `raise_errors` function for raising errors from `Failure.alt`
- Export `ErrorElement` just to make tests easier