### PR TITLE
Include class docstrings as description in OpenAPI schema

### DIFF
--- a/src/serialite/_base.py
+++ b/src/serialite/_base.py
@@ -156,14 +156,7 @@ class Serializable(Serializer[Self]):
             )
             return ref_json_schema
 
-        schema = cls.to_openapi_schema(serializer_to_pydantic_ref, force=True)
-
-        # Pydantic v2 delegates schema generation entirely to __get_pydantic_json_schema__, so we
-        # need to inject it ourselves.
-        if cls.__doc__ is not None and "description" not in schema:
-            schema["description"] = cls.__doc__
-
-        return schema
+        return cls.to_openapi_schema(serializer_to_pydantic_ref, force=True)
 
     @classproperty
     def model_fields(cls):

--- a/src/serialite/_base.py
+++ b/src/serialite/_base.py
@@ -156,7 +156,14 @@ class Serializable(Serializer[Self]):
             )
             return ref_json_schema
 
-        return cls.to_openapi_schema(serializer_to_pydantic_ref, force=True)
+        schema = cls.to_openapi_schema(serializer_to_pydantic_ref, force=True)
+
+        # Pydantic v2 delegates schema generation entirely to __get_pydantic_json_schema__, so we
+        # need to inject it ourselves.
+        if cls.__doc__ is not None and "description" not in schema:
+            schema["description"] = cls.__doc__
+
+        return schema
 
     @classproperty
     def model_fields(cls):

--- a/src/serialite/_mixins.py
+++ b/src/serialite/_mixins.py
@@ -51,6 +51,9 @@ class SerializableMixin(Serializable):
                 discriminator_field = {"_type": {"type": "string", "enum": [cls.__name__]}}
                 schema = schema | {"properties": discriminator_field | schema["properties"]}
 
+            if cls.__doc__ is not None:
+                schema = schema | {"description": cls.__doc__}
+
             return schema
         else:
             return serializer_to_ref(cls)
@@ -135,7 +138,7 @@ class AbstractSerializableMixin(Serializable):
     @classmethod
     def to_openapi_schema(cls, serializer_to_ref: SerializerToRef, *, force: bool = False) -> Any:
         if force:
-            return {
+            schema = {
                 "type": "object",
                 "discriminator": {"propertyName": "_type"},
                 "oneOf": [
@@ -143,5 +146,10 @@ class AbstractSerializableMixin(Serializable):
                     for subclass in cls.__subclass_serializers__.values()
                 ],
             }
+
+            if cls.__doc__ is not None:
+                schema["description"] = cls.__doc__
+
+            return schema
         else:
             return serializer_to_ref(cls)

--- a/tests/fastapi/test_concrete.py
+++ b/tests/fastapi/test_concrete.py
@@ -192,6 +192,60 @@ def test_fastapi_not_too_strict(client_fixture, request):
     assert isinstance(response.json()["foo"]["b"], float)
 
 
+def test_docstring_in_schema():
+    app = FastAPI()
+
+    @serializable
+    @dataclass(frozen=True)
+    class DocumentedDataclass:
+        """User docstring."""
+
+        x: int
+
+    @serializable
+    @dataclass(frozen=True)
+    class UndocumentedDataclass:
+        x: int
+
+    class DocumentedMixin(SerializableMixin):
+        """Mixin docstring."""
+
+        __fields_serializer__ = FieldsSerializer(x=int)
+
+        def __init__(self, x: int):
+            self.x = x
+
+    class UndocumentedMixin(SerializableMixin):
+        __fields_serializer__ = FieldsSerializer(x=int)
+
+        def __init__(self, x: int):
+            self.x = x
+
+    @app.post("/a")
+    def a(v: DocumentedDataclass) -> DocumentedDataclass:
+        return v
+
+    @app.post("/b")
+    def b(v: UndocumentedDataclass) -> UndocumentedDataclass:
+        return v
+
+    @app.post("/c")
+    def c(v: DocumentedMixin) -> DocumentedMixin:
+        return v
+
+    @app.post("/d")
+    def d(v: UndocumentedMixin) -> UndocumentedMixin:
+        return v
+
+    client = TestClient(app)
+    schemas = client.get("/openapi.json").json()["components"]["schemas"]
+
+    assert schemas["DocumentedDataclass"]["description"] == "User docstring."
+    assert schemas["UndocumentedDataclass"]["description"] == "UndocumentedDataclass(x: int)"
+    assert schemas["DocumentedMixin"]["description"] == "Mixin docstring."
+    assert "description" not in schemas["UndocumentedMixin"]
+
+
 @pytest.fixture
 def fastapi_pydantic_client():
     app = FastAPI()


### PR DESCRIPTION
Class docstrings were not showing up as "description" in the OpenAPI schema. This is because Pydantic v2 delegates schema generation entirely to `__get_pydantic_json_schema__`, which we override, and we weren't injecting `cls.__doc__` into the result.