### PR TITLE
Define `Result` as a union of `Success` and `Failure` to express a closed sum type

### DIFF
--- a/src/serialite/_result.py
+++ b/src/serialite/_result.py
@@ -6,8 +6,8 @@ from returns import result
 
 from ._errors import Errors
 
-type Result[Output] = result.Result[Output, Errors]
-
 Success = result.Success
 Failure: type[result.Failure[Errors]] = result.Failure[Errors]
 Failure = result.Failure
+
+type Result[Output] = Success[Output] | Failure


### PR DESCRIPTION
`serialite.Result` aliases the `returns` abstract base class `Result`. A type checker cannot prove a `match` on it is exhaustive, even when both `Success` and `Failure` are handled.

MRE:

```python
from serialite import Failure, Result, Success, raise_errors

def unwrap(r: Result[int]) -> int:
    match r:
        case Success(value):
            return value
        case Failure(errors):
            raise_errors(errors)
```

Both arms return or raise (`raise_errors` is `NoReturn`), so this is exhaustive. `pyrefly` rejects it:

```
ERROR Function declared to return `int`, but one or more paths are missing an explicit `return` [bad-return]
```

A wildcard `case _ as other: assert_never(other)` shows the subject is never narrowed past the two arms:

```
ERROR Argument `Result[int, Errors]` is not assignable to parameter `arg` with type `Never` in function `typing.assert_never` [bad-argument-type]
```

Root cause:

`returns.result.Result` is an abstract base class. Nominal subclassing is open, so a checker must assume a third subclass could exist. Making `Result` a union of exactly `Success` and `Failure` fixes this. Each case eliminates one arm, and the match narrows to `Never`. A union is needed because Python has no sealed to close the base class.