### PR TITLE
Dispatch `Serializable` subclasses of registered types to themselves

### DIFF
--- a/src/serialite/_dispatcher.py
+++ b/src/serialite/_dispatcher.py
@@ -7,7 +7,7 @@ from types import GenericAlias, UnionType
 from typing import Any, Literal, NewType, TypeAliasType, Union, get_origin
 from uuid import UUID
 
-from ._base import Serializer
+from ._base import Serializable, Serializer
 
 
 def subclassdispatch(func):
@@ -51,6 +51,15 @@ def subclassdispatch(func):
     registry = {}
     dispatch_cache = WeakKeyDictionary()
     cache_token = None
+
+    def is_own_serializer(cls):
+        """Whether `cls` serializes its own instances rather than a base's.
+
+        A `Serializable` subclass defines `from_data`/`to_data` on itself, so it
+        is its own serializer. That must win over the MRO lookup in `_find_impl`,
+        which would otherwise pick a base class's registered serializer.
+        """
+        return cls not in registry and issubclass(cls, Serializable)
 
     def dispatch(cls: type):
         """generic_func.dispatch(cls) -> <function implementation>
@@ -97,12 +106,17 @@ def subclassdispatch(func):
                     if origin is Literal:
                         # issubclass does not work on Literal either
                         impl = literal_serializer
+                    elif is_own_serializer(origin):
+                        # e.g. a generic Serializable subclass such as Box[int]
+                        impl = registry[object]
                     else:
                         # This is the standard Generic class
                         impl = _find_impl(origin, registry)
                 elif cls is Any:
                     # issubclass does not work on Any; must directly inject this
                     impl = any_serializer
+                elif is_own_serializer(cls):
+                    impl = registry[object]
                 else:
                     impl = _find_impl(cls, registry)
             dispatch_cache[cls] = impl

--- a/tests/fastapi/test_custom_scalar.py
+++ b/tests/fastapi/test_custom_scalar.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from serialite import (
+    Errors,
+    ExpectedStringError,
+    Failure,
+    Serializable,
+    Success,
+    ValidationError,
+    serializable,
+)
+
+# A custom scalar is a Serializable subclass of a type that already has a builtin
+# serializer (here UUID). The dispatcher must use the subclass's own from_data/
+# to_data. And since it is not an OpenAPI component, its schema is inlined into
+# the owning model rather than emitted as a separate $ref.
+
+
+class UUID7(UUID, Serializable):
+    """A UUID constrained to version 7."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.version != 7:
+            raise ValueError(f"Not a version 7 UUID: {self}")
+
+    @classmethod
+    def from_data(cls, data):
+        if not isinstance(data, str):
+            return Failure(Errors.one(ExpectedStringError(data)))
+        try:
+            value = cls(data)
+        except ValueError:
+            error = ValidationError(f"Expected UUID version 7, but got {data!r}")
+            return Failure(Errors.one(error))
+        return Success(value)
+
+    def to_data(self):
+        return str(self)
+
+    @classmethod
+    def to_openapi_schema(cls, serializer_to_ref, *, force=False):
+        return {"type": "string", "format": "uuid"}
+
+
+@serializable
+@dataclass(frozen=True)
+class Event:
+    id: UUID7
+
+
+valid_v7 = "018f8f8f-8f8f-7f8f-8f8f-8f8f8f8f8f8f"
+non_v7 = "00112233-4455-6677-8899-aabbccddeeff"
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+
+    @app.post("/", response_model=Event)
+    def echo(event: Event) -> Event:
+        return event
+
+    return TestClient(app)
+
+
+def test_schema_is_inlined(client):
+    schemas = client.get("/openapi.json").json()["components"]["schemas"]
+
+    # UUID7 is not an OpenAPI component, so its schema is inlined into the
+    # owning property rather than emitted as a separate $ref component.
+    assert schemas["Event"]["properties"]["id"] == {"type": "string", "format": "uuid"}
+    assert "UUID7" not in schemas
+
+
+def test_round_trip(client):
+    response = client.post("/", json={"id": valid_v7})
+    assert response.status_code == 200
+    assert response.json() == {"id": valid_v7}
+
+
+def test_validation_error_propagates(client):
+    response = client.post("/", json={"id": non_v7})
+    assert response.status_code == 422
+
+    detail = response.json()["detail"]
+    assert len(detail) == 1
+    assert detail[0]["type"] == "ValidationError"
+    assert detail[0]["loc"] == ["body", "id"]
+    assert detail[0]["msg"] == f"Expected UUID version 7, but got {non_v7!r}"

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -4,7 +4,15 @@ from uuid import UUID
 
 import pytest
 
-from serialite import Success, serializer
+from serialite import (
+    Errors,
+    Failure,
+    Serializable,
+    StringSerializer,
+    Success,
+    ValidationError,
+    serializer,
+)
 
 
 @pytest.mark.parametrize(
@@ -134,3 +142,75 @@ def test_dispatch_dict_with_nested_type_alias_str_key():
     dict_serializer = serializer(dict[NestedKey, int])
     assert dict_serializer.from_data({"a": 1, "b": 2}) == Success({"a": 1, "b": 2})
     assert dict_serializer.to_data({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+
+
+def test_dispatch_serializable_subclass_of_registered_type():
+    class Tag(str, Serializable):
+        @classmethod
+        def from_data(cls, data):
+            if not isinstance(data, str) or not data.startswith("tag:"):
+                return Failure(Errors.one(ValidationError(f"Not a tag: {data!r}")))
+            return Success(cls(data))
+
+        def to_data(self):
+            return str(self)
+
+    tag_serializer = serializer(Tag)
+    assert tag_serializer is Tag  # the class is its own serializer
+
+    # Recovering a Tag (not a plain str) proves Tag.from_data/to_data run.
+    assert isinstance(tag_serializer.from_data("tag:x").unwrap(), Tag)
+    assert tag_serializer.to_data(Tag("tag:x")) == "tag:x"
+
+    # A plain string is accepted by the builtin StringSerializer but must be
+    # rejected here, proving Tag.from_data runs rather than StringSerializer.
+    assert isinstance(tag_serializer.from_data("plain"), Failure)
+
+
+def test_dispatch_explicit_registration_overrides_serializable_subclass():
+    class Widget(str, Serializable):
+        pass
+
+    override = StringSerializer()
+    serializer.register(Widget, lambda cls: override)
+
+    assert serializer(Widget) is override
+
+
+def test_dispatch_generic_serializable_subclass_of_registered_type():
+    class TypedList[T](list, Serializable):
+        @classmethod
+        def from_data(cls, data):
+            if not isinstance(data, list):
+                return Failure(Errors.one(ValidationError(f"Not a list: {data!r}")))
+            return Success(cls(data))
+
+        def to_data(self):
+            return list(self)
+
+    typed_list_serializer = serializer(TypedList[int])
+
+    # The builtin list serializer would yield a plain list. Recovering a
+    # TypedList proves TypedList.from_data runs instead of ListSerializer.
+    parsed = typed_list_serializer.from_data([1, 2, 3])
+    assert isinstance(parsed.unwrap(), TypedList)
+    assert typed_list_serializer.to_data(TypedList([1, 2, 3])) == [1, 2, 3]
+
+
+def test_dispatch_generic_serializable_subclass_without_registered_base():
+    class Box[T](Serializable):
+        def __init__(self, value):
+            self.value = value
+
+        @classmethod
+        def from_data(cls, data):
+            return Success(cls(data["value"]))
+
+        def to_data(self):
+            return {"value": self.value}
+
+    # Unlike TypedList (whose origin subclasses the registered list), Box's
+    # origin has no registered serializer. This covers the plain generic path.
+    box_serializer = serializer(Box[int])
+    assert box_serializer.from_data({"value": 7}).unwrap().value == 7
+    assert box_serializer.to_data(Box(7)) == {"value": 7}


### PR DESCRIPTION
A `Serializable` subclass that also inherits a type with a registered serializer, for example, `class UUID7(UUID, Serializable)`, `class Tag(str, Serializable)`, used to silently dispatch to the base's serializer (the MRO walk found `UuidSerializer`/`StringSerializer` first), so its own `from_data`/`to_data` were ignored. This makes such a class win as its own serializer, which is what enables defining custom scalar types.

An explicit `serializer.register(...)` still takes precedence over this rule, and the same handling applies to generic origins (`Box[int]`, `TypedList[int]`). Since a custom scalar typically isn't an OpenAPI component, its schema is inlined into the owning model rather than emitted as a separate `$ref`.