### PR TITLE
Allow `ValidationExceptionGroup` to propagate through context managers

### DIFF
--- a/src/serialite/_errors.py
+++ b/src/serialite/_errors.py
@@ -24,7 +24,9 @@ class ValidationError(Exception):
         return self.message
 
 
-@dataclass(frozen=True, slots=True, init=False)
+# Not frozen: as an exception unwinds, contextlib (and similar) assign
+# __traceback__ at the Python level, which a frozen __setattr__ would reject.
+@dataclass(init=False)
 class ValidationExceptionGroup(ExceptionGroup):
     """An ExceptionGroup raised by Errors.raise_on_errors.
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 import pytest
@@ -156,3 +157,18 @@ def test_raise_errors_in_alt():
 def test_raise_errors_on_empty():
     with pytest.raises(ValueError):
         raise_errors(Errors())
+
+
+def test_raise_errors_propagates_through_context_manager():
+    @contextmanager
+    def resource():
+        yield
+
+    real_error = ValueError("the real error")
+    errors = Errors.one(real_error, location=["path"])
+
+    with pytest.raises(ValidationExceptionGroup) as exc_info:
+        with resource():
+            raise_errors(errors)
+
+    assert exc_info.value.errors == (ErrorElement(real_error, location=("path",)),)


### PR DESCRIPTION
`ValidationExceptionGroup` was a frozen dataclass. When raised inside a context manager, `contextlib`'s `__exit__` assigns `exc.__traceback__` at the Python level as the exception unwinds, and the frozen `__setattr__` rejected it masking the real error. Ordinary propagation was unaffected because the interpreter sets the traceback at the C level, bypassing `__setattr__`.